### PR TITLE
Add missing v2 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ Tools for acquiring and analyzing Oura API data.
 - [API Requests](#api-requests)
   - [Get Personal Info](#get-personal-info)
   - [Get Daily Sleep](#get-daily-sleep)
+  - [Get Daily SpO2](#get-daily-spo2)
+  - [Get Daily Stress](#get-daily-stress)
   - [Get Daily Activity](#get-daily-activity)
   - [Get Daily Readiness](#get-daily-readiness)
+  - [Get Enhanced Tag](#get-enhanced-tag)
   - [Get Heart Rate](#get-heart-rate)
+  - [Get Ring Configuration](#get-ring-configuration)
+  - [Get Rest Mode Period](#get-rest-mode-period)
   - [Get Sleep Periods](#get-sleep-periods)
+  - [Get Sleep Time](#get-sleep-time)
   - [Get Sessions](#get-sessions)
   - [Get Tags](#get-tags)
   - [Get Workouts](#get-workouts)
@@ -76,6 +82,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 
 ```python
 {
+    "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
     "age": 31,
     "weight": 74.8,
     "height": 1.8,
@@ -98,6 +105,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ```python
 [
     {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
         "contributors": {
             "deep_sleep": 57,
             "efficiency": 98,
@@ -129,6 +137,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ```python
 [
     {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
         "class_5_min": "<long sequence of 0|1|2|3|4|5>",
         "score": 82,
         "active_calories": 1222,
@@ -187,6 +196,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ```python
 [
     {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
         "contributors": {
             "activity_balance": 56,
             "body_temperature": 98,
@@ -205,6 +215,33 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
     },
     ...
 ]
+```
+
+### Get Enhanced Tag
+
+**Method**: `get_enhanced_tag(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
+
+**Payload**:
+
+- `start_date`: The earliest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to one day before the `end_date` parameter.
+- `end_date`: The latest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to today's date.
+
+**Example Response**:
+
+```python
+[
+    {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+        "tag_type_code": "string",
+        "start_time": "2019-08-24T14:15:22Z",
+        "end_time": "2019-08-24T14:15:22Z",
+        "start_day": "2019-08-24",
+        "end_day": "2019-08-24",
+        "comment": "string"
+    },
+    ...
+]
+
 ```
 
 ### Get Heart Rate
@@ -243,6 +280,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ```python
 [
     {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
         "average_breath": 12.625,
         "average_heart_rate": 4.25,
         "average_hrv": 117,
@@ -291,6 +329,92 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ]
 ```
 
+### Get Sleep Time
+
+**Method**: `get_sleep_time(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
+
+**Payload**:
+
+- `start_date`: The earliest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to one day before the `end_date` parameter.
+- `end_date`: The latest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to today's date.
+
+**Example Response**:
+
+```python
+[
+    {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+        "day": "2019-08-24",
+        "optimal_bedtime": {
+            "day_tz": 0,
+            "end_offset": 0,
+            "start_offset": 0
+        },
+        "recommendation": "improve_efficiency",
+        "status": "not_enough_nights"
+    },
+    ...
+]
+```
+
+### Get Ring Configuration
+
+**Method**: `get_ring_configuration(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
+
+**Payload**:
+
+- `start_date`: The earliest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to one day before the `end_date` parameter.
+- `end_date`: The latest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to today's date.
+
+**Example Response**:
+
+```python
+[
+    {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+        "color": "glossy_black",
+        "design": "heritage",
+        "firmware_version": "string",
+        "hardware_type": "gen1",
+        "set_up_at": "2019-08-24T14:15:22Z",
+        "size": 0
+    },
+    ...
+]
+```
+
+### Get Rest Mode Period
+
+**Method**: `get_rest_mode_period(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
+
+**Payload**:
+
+- `start_date`: The earliest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to one day before the `end_date` parameter.
+- `end_date`: The latest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to today's date.
+
+**Example Response**:
+
+```python
+[
+    {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+        "end_day": "2019-08-24",
+        "end_time": "2019-08-24T14:15:22Z",
+        "episodes": [
+            {
+                "tags": [
+                      "string"
+                ],
+                "timestamp": "2019-08-24T14:15:22Z"
+            }
+        ],
+        "start_day": "2019-08-24",
+        "start_time": "2019-08-24T14:15:22Z"
+    },
+    ...
+]
+```
+
 ### Get Sessions
 
 **Method**: `get_sessions(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
@@ -305,6 +429,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ```python
 [
     {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
         "day": "2021-11-12",
         "start_datetime": "2021-11-12T12:32:09-08:00",
         "end_datetime": "2021-11-12T12:40:49-08:00",
@@ -324,6 +449,54 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ]
 ```
 
+### Get Daily SpO2
+
+**Method**: `get_daily_spo2(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
+
+**Payload**:
+
+- `start_date`: The earliest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to one day before the `end_date` parameter.
+- `end_date`: The latest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to today's date.
+
+**Example Response**:
+
+```python
+[
+    {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+        "day": "2019-08-24",
+        "spo2_percentage": {
+            "average": 0
+        }
+    },
+  ...
+]
+```
+
+### Get Daily Stress
+
+**Method**: `get_daily_stress(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
+
+**Payload**:
+
+- `start_date`: The earliest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to one day before the `end_date` parameter.
+- `end_date`: The latest date for which to get data. Expected in ISO 8601 format (YYYY-MM-DD). Defaults to today's date.
+
+**Example Response**:
+
+```python
+[
+    {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+        "day": "2019-08-24",
+        "stress_high": 0,
+        "recovery_high": 0,
+        "day_summary": "restored"
+    },
+    ...
+]
+```
+
 ### Get Tags
 
 **Method**: `get_tags(start_date: str = <end_date - 1 day>, end_date: str = <today's date>)`
@@ -338,6 +511,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ```python
 [
     {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
         "day": "2021-01-01",
         "text": "Need coffee",
         "timestamp": "2021-01-01T01:02:03-08:00",
@@ -363,6 +537,7 @@ There are nine different API requests that `OuraClient` can make. Full Oura API 
 ```python
 [
     {
+        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
         "activity": "cycling",
         "calories": 300,
         "day": "2021-01-01",

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -170,6 +170,48 @@ class OuraClient:
             params={"start_date": start, "end_date": end},
         )
 
+    def get_daily_spo2(
+            self,
+            start_date: str | None = None,
+            end_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Make request to Get Daily Spo2 endpoint.
+
+        Returns Oura Daily Spo2 data for the specified Oura user within a given
+        timeframe.
+
+        The Daily SpO2 (blood oxygenation) routes include daily SpO2 average.
+        Data will only be available for users with a Gen 3 Oura Ring.
+
+        Args:
+            start_date (str, optional): The earliest date for which to get data.
+                Expected in ISO 8601 format (`YYYY-MM-DD`). Defaults to one day
+                before `end_date`.
+            end_date (str, optional): The latest date for which to get data. Expected
+                in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+
+        Returns:
+            list[dict[str, Any]]: Response JSON data loaded into an object.
+                Example:
+                    [
+                        {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                            "day": "2019-08-24",
+                            "spo2_percentage": {
+                                "average": 0
+                            }
+                        },
+                        ...
+                    ]
+        """
+        start, end = self._format_dates(start_date, end_date)
+
+        return self._make_paginated_request(
+            method="GET",
+            url_slug="v2/usercollection/daily_spo2",
+            params={"start_date": start, "end_date": end},
+        )
+
     def get_daily_activity(
         self,
         start_date: str | None = None,

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -170,6 +170,50 @@ class OuraClient:
             params={"start_date": start, "end_date": end},
         )
 
+    def get_ring_configuration(
+            self,
+            start_date: str | None = None,
+            end_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Make request to Get Ring Configuration endpoint.
+
+        Returns Oura Ring Configuration data for the specified Oura user within
+        a given timeframe.
+
+        The Ring Configuration scope includes information about the user's
+        ring(s). This includes the model, size, color, etc.
+
+        Args:
+            start_date (str, optional): The earliest date for which to get data.
+                Expected in ISO 8601 format (`YYYY-MM-DD`). Defaults to one day
+                before `end_date`.
+            end_date (str, optional): The latest date for which to get data. Expected
+                in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+
+        Returns:
+            list[dict[str, Any]]: Response JSON data loaded into an object.
+                Example:
+                    [
+                        {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                            "color": "glossy_black",
+                            "design": "heritage",
+                            "firmware_version": "string",
+                            "hardware_type": "gen1",
+                            "set_up_at": "2019-08-24T14:15:22Z",
+                            "size": 0
+                        },
+                        ...
+                    ]
+        """
+        start, end = self._format_dates(start_date, end_date)
+
+        return self._make_paginated_request(
+            method="GET",
+            url_slug="v2/usercollection/ring_configuration",
+            params={"start_date": start, "end_date": end},
+        )
+
     def get_daily_sleep(
         self,
         start_date: str | None = None,

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -603,7 +603,7 @@ class OuraClient:
         end_date: str | None = None,
         document_id: str | None = None,
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Make request to Get Daily Activy endpoint.
+        """Make request to Get Daily Activity endpoint.
 
         Returns Oura Daily Activity data for the specified Oura user within a given
         timeframe.

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -120,6 +120,56 @@ class OuraClient:
             method="GET", url_slug="v2/usercollection/personal_info"
         )
 
+    def get_rest_mode_period(
+            self,
+            start_date: str | None = None,
+            end_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Make request to Get Rest Mode Period endpoint.
+
+        Returns Oura Rest Mode Period data for the specified Oura user within
+        a given timeframe.
+
+        The Rest Mode scope includes information about rest mode periods. This
+        includes the start, end time and details of the rest mode period.
+
+        Args:
+            start_date (str, optional): The earliest date for which to get data.
+                Expected in ISO 8601 format (`YYYY-MM-DD`). Defaults to one day
+                before `end_date`.
+            end_date (str, optional): The latest date for which to get data. Expected
+                in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+
+        Returns:
+            list[dict[str, Any]]: Response JSON data loaded into an object.
+                Example:
+                    [
+                        {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                            "end_day": "2019-08-24",
+                            "end_time": "2019-08-24T14:15:22Z",
+                            "episodes": [
+                                {
+                                    "tags": [
+                                        "string"
+                                    ],
+                                    "timestamp": "2019-08-24T14:15:22Z"
+                                }
+                            ],
+                            "start_day": "2019-08-24",
+                            "start_time": "2019-08-24T14:15:22Z"
+                        },
+                        ...
+                    ]
+        """
+        start, end = self._format_dates(start_date, end_date)
+
+        return self._make_paginated_request(
+            method="GET",
+            url_slug="v2/usercollection/rest_mode_period",
+            params={"start_date": start, "end_date": end},
+        )
+
     def get_daily_sleep(
         self,
         start_date: str | None = None,

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -214,6 +214,52 @@ class OuraClient:
             params={"start_date": start, "end_date": end},
         )
 
+    def get_sleep_time(
+            self,
+            start_date: str | None = None,
+            end_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Make request to Get Sleep Time endpoint.
+
+        Returns Oura Sleep Time data for the specified Oura user within a given
+        timeframe.
+
+        Recommendations for the optimal bedtime window that is calculated based
+        on sleep data.
+
+        Args:
+            start_date (str, optional): The earliest date for which to get data.
+                Expected in ISO 8601 format (`YYYY-MM-DD`). Defaults to one day
+                before `end_date`.
+            end_date (str, optional): The latest date for which to get data. Expected
+                in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+
+        Returns:
+            list[dict[str, Any]]: Response JSON data loaded into an object.
+                Example:
+                    [
+                        {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                            "day": "2019-08-24",
+                            "optimal_bedtime": {
+                                "day_tz": 0,
+                                "end_offset": 0,
+                                "start_offset": 0
+                            },
+                            "recommendation": "improve_efficiency",
+                            "status": "not_enough_nights"
+                        },
+                        ...
+                    ]
+        """
+        start, end = self._format_dates(start_date, end_date)
+
+        return self._make_paginated_request(
+            method="GET",
+            url_slug="v2/usercollection/sleep_time",
+            params={"start_date": start, "end_date": end},
+        )
+
     def get_daily_sleep(
         self,
         start_date: str | None = None,

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -258,6 +258,53 @@ class OuraClient:
             params={"start_date": start, "end_date": end},
         )
 
+    def get_enhanced_tag(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Make request to Get Enhanced Tag endpoint.
+
+        Returns Oura Enhanced Tag data for the specified Oura user within a given
+        timeframe.
+
+        The Enhanced Tags data scope includes tags that Oura users enter within
+        the Oura mobile app. Enhanced Tags can be added for any lifestyle
+        choice, habit, mood change, or environmental factor an Oura user wants
+        to monitor the effects of. Enhanced Tags also contain context on a
+        tag’s start and end time, whether a tag repeats daily, and comments.
+
+        Args:
+            start_date (str, optional): The earliest date for which to get data.
+                Expected in ISO 8601 format (`YYYY-MM-DD`). Defaults to one day
+                before `end_date`.
+            end_date (str, optional): The latest date for which to get data. Expected
+                in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+
+        Returns:
+            list[dict[str, Any]]: Response JSON data loaded into an object.
+                Example:
+                    [
+                        {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                            "tag_type_code": "string",
+                            "start_time": "2019-08-24T14:15:22Z",
+                            "end_time": "2019-08-24T14:15:22Z",
+                            "start_day": "2019-08-24",
+                            "end_day": "2019-08-24",
+                            "comment": "string"
+                        },
+                        ...
+                    ]
+        """
+        start, end = self._format_dates(start_date, end_date)
+
+        return self._make_paginated_request(
+            method="GET",
+            url_slug="v2/usercollection/enhanced_tag",
+            params={"start_date": start, "end_date": end},
+        )
+
     def get_daily_activity(
         self,
         start_date: str | None = None,

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -124,7 +124,8 @@ class OuraClient:
             self,
             start_date: str | None = None,
             end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+            document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Rest Mode Period endpoint.
 
         Returns Oura Rest Mode Period data for the specified Oura user within
@@ -139,6 +140,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -161,8 +165,32 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "end_day": "2019-08-24",
+                        "end_time": "2019-08-24T14:15:22Z",
+                        "episodes": [
+                            {
+                                "tags": [
+                                    "string"
+                                ],
+                                "timestamp": "2019-08-24T14:15:22Z"
+                            }
+                        ],
+                        "start_day": "2019-08-24",
+                        "start_time": "2019-08-24T14:15:22Z"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/rest_mode_period/{document_id}"
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -174,7 +202,8 @@ class OuraClient:
             self,
             start_date: str | None = None,
             end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+            document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Ring Configuration endpoint.
 
         Returns Oura Ring Configuration data for the specified Oura user within
@@ -189,6 +218,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -205,8 +237,26 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "color": "glossy_black",
+                        "design": "heritage",
+                        "firmware_version": "string",
+                        "hardware_type": "gen1",
+                        "set_up_at": "2019-08-24T14:15:22Z",
+                        "size": 0
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/ring_configuration/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -218,7 +268,8 @@ class OuraClient:
             self,
             start_date: str | None = None,
             end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+            document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Sleep Time endpoint.
 
         Returns Oura Sleep Time data for the specified Oura user within a given
@@ -233,6 +284,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -251,8 +305,28 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "day": "2019-08-24",
+                        "optimal_bedtime": {
+                            "day_tz": 0,
+                            "end_offset": 0,
+                            "start_offset": 0
+                        },
+                        "recommendation": "improve_efficiency",
+                        "status": "not_enough_nights"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/sleep_time/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -264,7 +338,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Daily Sleep endpoint.
 
         Returns Oura Daily Sleep data for the specified Oura user within a given
@@ -279,6 +354,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -301,8 +379,32 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "contributors": {
+                            "deep_sleep": 57,
+                            "efficiency": 98,
+                            "latency": 81,
+                            "rem_sleep": 20,
+                            "restfulness": 54,
+                            "timing": 84,
+                            "total_sleep": 60
+                        },
+                        "day": "2022-07-14",
+                        "score": 63,
+                        "timestamp": "2022-07-14T00:00:00+00:00"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/daily_sleep/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -314,7 +416,8 @@ class OuraClient:
             self,
             start_date: str | None = None,
             end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+            document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Daily Spo2 endpoint.
 
         Returns Oura Daily Spo2 data for the specified Oura user within a given
@@ -329,6 +432,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -343,8 +449,24 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "day": "2019-08-24",
+                        "spo2_percentage": {
+                            "average": 0
+                        }
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/daily_spo2/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -356,7 +478,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Daily Stress endpoint.
 
         Returns Oura Daily Stress data for the specified Oura user within a given
@@ -375,6 +498,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -389,8 +515,24 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "day": "2019-08-24",
+                        "stress_high": 0,
+                        "recovery_high": 0,
+                        "day_summary": "restored"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/daily_stress/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -402,7 +544,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Enhanced Tag endpoint.
 
         Returns Oura Enhanced Tag data for the specified Oura user within a given
@@ -420,6 +563,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -439,6 +585,12 @@ class OuraClient:
         """
         start, end = self._format_dates(start_date, end_date)
 
+        if document_id:
+            return self._make_paginated_request(
+                method="GET",
+                url_slug=f"v2/usercollection/enhanced_tag/{document_id}",
+            )
+
         return self._make_paginated_request(
             method="GET",
             url_slug="v2/usercollection/enhanced_tag",
@@ -449,7 +601,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Daily Activy endpoint.
 
         Returns Oura Daily Activity data for the specified Oura user within a given
@@ -465,6 +618,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -514,8 +670,59 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "class_5_min": "<long sequence of 0|1|2|3|4|5>",
+                        "score": 82,
+                        "active_calories": 1222,
+                        "average_met_minutes": 1.90625,
+                        "contributors": {
+                            "meet_daily_targets": 43,
+                            "move_every_hour": 100,
+                            "recovery_time": 100,
+                            "stay_active": 98,
+                            "training_frequency": 71,
+                            "training_volume": 98
+                        },
+                        "equivalent_walking_distance": 20122,
+                        "high_activity_met_minutes": 444,
+                        "high_activity_time": 3000,
+                        "inactivity_alerts": 0,
+                        "low_activity_met_minutes": 117,
+                        "low_activity_time": 10020,
+                        "medium_activity_met_minutes": 391,
+                        "medium_activity_time": 6060,
+                        "met": {
+                            "interval": 60,
+                            "items": [
+                                0.1,
+                                ...
+                            ],
+                            "timestamp": "2021-11-26T04:00:00.000-08:00"
+                        },
+                        "meters_to_target": -16200,
+                        "non_wear_time": 27480,
+                        "resting_time": 18840,
+                        "sedentary_met_minutes": 10,
+                        "sedentary_time": 21000,
+                        "steps": 18430,
+                        "target_calories": 350,
+                        "target_meters": 7000,
+                        "total_calories": 3446,
+                        "day": "2021-11-26",
+                        "timestamp": "2021-11-26T04:00:00-08:00"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/daily_activity/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -527,7 +734,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Daily Readiness endpoint.
 
         Returns Oura Daily Readiness data for the specified Oura user within a given
@@ -541,6 +749,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -566,8 +777,35 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "contributors": {
+                            "activity_balance": 56,
+                            "body_temperature": 98,
+                            "hrv_balance": 75,
+                            "previous_day_activity": None,
+                            "previous_night": 35,
+                            "recovery_index": 47,
+                            "resting_heart_rate": 94,
+                            "sleep_balance": 73
+                        },
+                        "day": "2021-10-27",
+                        "score": 66,
+                        "temperature_deviation": -0.2,
+                        "temperature_trend_deviation": 0.1,
+                        "timestamp": "2021-10-27T00:00:00+00:00"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/daily_readiness/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -620,7 +858,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Sleep Periods endpoint.
 
         Returns available Oura sleep data for the specified Oura user within a given
@@ -635,6 +874,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -688,8 +930,63 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "average_breath": 12.625,
+                        "average_heart_rate": 4.25,
+                        "average_hrv": 117,
+                        "awake_time": 4800,
+                        "bedtime_end": "2022-07-12T09:25:14-07:00",
+                        "bedtime_start": "2022-07-12T01:05:14-07:00",
+                        "day": "2022-07-12",
+                        "deep_sleep_duration": 4170,
+                        "efficiency": 84,
+                        "heart_rate": {
+                            "interval": 300,
+                            "items": [
+                                None,
+                                50,
+                                46,
+                                ...
+                            ],
+                            "timestamp": "2022-07-12T01:05:14.000-07:00"
+                        },
+                        "hrv": {
+                            "interval": 300,
+                            "items": [
+                                None,
+                                -102,
+                                -122,
+                                ...
+                            ],
+                            "timestamp": "2022-07-12T01:05:14.000-07:00"
+                        },
+                        "latency": 540,
+                        "light_sleep_duration": 18750,
+                        "low_battery_alert": False,
+                        "lowest_heart_rate": 48,
+                        "movement_30_sec": "<long sequence of 1|2|3>",
+                        "period": 0,
+                        "readiness_score_delta": 0,
+                        "rem_sleep_duration": 2280,
+                        "restless_periods": 415,
+                        "sleep_phase_5_min": "<long sequence of 1|2|3|4>",
+                        "sleep_score_delta": 0,
+                        "time_in_bed": 30000,
+                        "total_sleep_duration": None,
+                        "type": "long_sleep"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/sleep/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -701,7 +998,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Sessions endpoint.
 
         Returns available Oura session data for the specified Oura user within a given
@@ -717,6 +1015,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -741,8 +1042,33 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "day": "2021-11-12",
+                        "start_datetime": "2021-11-12T12:32:09-08:00",
+                        "end_datetime": "2021-11-12T12:40:49-08:00",
+                        "type": "rest",
+                        "heart_rate": None,
+                        "heart_rate_variability": None,
+                        "mood": None,
+                        "motion_count": {
+                            "interval": 5,
+                            "items": [
+                                0
+                            ],
+                            "timestamp": "2021-11-12T12:32:09.000-08:00"
+                        }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/session/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -754,10 +1080,13 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Tags endpoint.
 
         Returns Oura tags data for the specified Oura user within a given timeframe.
+
+        Note: Tag is deprecated. We recommend transitioning to Enhanced Tag.
 
         The Tags data scope includes tags that Oura users enter within the Oura mobile
         app. Tags are a growing list of activities, environment factors, symptoms,
@@ -770,6 +1099,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -786,8 +1118,26 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "day": "2021-01-01",
+                        "text": "Need coffee",
+                        "timestamp": "2021-01-01T01:02:03-08:00",
+                        "tags": [
+                            "tag_generic_nocaffeine"
+                        ]
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/tag/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",
@@ -799,7 +1149,8 @@ class OuraClient:
         self,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> list[dict[str, Any]]:
+        document_id: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Make request to Get Workouts endpoint.
 
         Returns available Oura workout data for the specified Oura user within a given
@@ -815,6 +1166,9 @@ class OuraClient:
                 before `end_date`.
             end_date (str, optional): The latest date for which to get data. Expected
                 in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+            document_id (str, options): Individual document id, listed at "id"
+                in responses.  Allows you to re-access a previous datapoint.
+                If present, start_date and end_date are ignored.
 
         Returns:
             list[dict[str, Any]]: Response JSON data loaded into an object.
@@ -834,8 +1188,29 @@ class OuraClient:
                         },
                         ...
                     ]
+
+            dict[str, Any]: Response JSON data loaded into an object.
+                Example:
+                    {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                        "activity": "cycling",
+                        "calories": 300,
+                        "day": "2021-01-01",
+                        "distance": 13500.5,
+                        "end_datetime": "2021-01-01T01:00:00.000000+00:00",
+                        "intensity": "moderate",
+                        "label": None,
+                        "source": "manual",
+                        "start_datetime": "2021-01-01T01:30:00.000000+00:00"
+                    }
         """
         start, end = self._format_dates(start_date, end_date)
+
+        if document_id:
+            return self._make_request(
+                method="GET",
+                url_slug=f"v2/usercollection/workout/{document_id}",
+            )
 
         return self._make_paginated_request(
             method="GET",

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -212,6 +212,52 @@ class OuraClient:
             params={"start_date": start, "end_date": end},
         )
 
+    def get_daily_stress(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Make request to Get Daily Stress endpoint.
+
+        Returns Oura Daily Stress data for the specified Oura user within a given
+        timeframe.
+
+        The daily stress route includes a summary of the number of minutes the user
+        spends in high stress and high recovery each day. This is a great way to
+        see how your stress and recovery are trending over time. Stress and
+        recovery are mutally exclusive. E.g. one can only be stressed or recovered
+        at any given moement - and cannot be stressed and recovered at the same
+        time.
+
+        Args:
+            start_date (str, optional): The earliest date for which to get data.
+                Expected in ISO 8601 format (`YYYY-MM-DD`). Defaults to one day
+                before `end_date`.
+            end_date (str, optional): The latest date for which to get data. Expected
+                in ISO 8601 format (`YYYY-MM-DD`). Defaults to today's date.
+
+        Returns:
+            list[dict[str, Any]]: Response JSON data loaded into an object.
+                Example:
+                    [
+                        {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
+                            "day": "2019-08-24",
+                            "stress_high": 0,
+                            "recovery_high": 0,
+                            "day_summary": "restored"
+                        },
+                        ...
+                    ]
+        """
+        start, end = self._format_dates(start_date, end_date)
+
+        return self._make_paginated_request(
+            method="GET",
+            url_slug="v2/usercollection/daily_stress",
+            params={"start_date": start, "end_date": end},
+        )
+
     def get_daily_activity(
         self,
         start_date: str | None = None,

--- a/oura_ring.py
+++ b/oura_ring.py
@@ -108,6 +108,7 @@ class OuraClient:
             dict[str, list[dict[str, Any]]]: Response JSON data loaded into an object.
                 Example:
                     {
+                        "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                         "age": 31,
                         "weight": 74.8,
                         "height": 1.8,
@@ -144,6 +145,7 @@ class OuraClient:
                 Example:
                     [
                         {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                             "contributors": {
                                 "deep_sleep": 57,
                                 "efficiency": 98,
@@ -194,6 +196,7 @@ class OuraClient:
                 Example:
                     [
                         {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                             "class_5_min": "<long sequence of 0|1|2|3|4|5>",
                             "score": 82,
                             "active_calories": 1222,
@@ -269,6 +272,7 @@ class OuraClient:
                 Example:
                     [
                         {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                             "contributors": {
                                 "activity_balance": 56,
                                 "body_temperature": 98,
@@ -362,6 +366,7 @@ class OuraClient:
                 Example:
                     [
                         {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                             "average_breath": 12.625,
                             "average_heart_rate": 4.25,
                             "average_hrv": 117,
@@ -443,6 +448,7 @@ class OuraClient:
                 Example:
                     [
                         {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                             "day": "2021-11-12",
                             "start_datetime": "2021-11-12T12:32:09-08:00",
                             "end_datetime": "2021-11-12T12:40:49-08:00",
@@ -495,6 +501,7 @@ class OuraClient:
                 Example:
                     [
                         {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                             "day": "2021-01-01",
                             "text": "Need coffee",
                             "timestamp": "2021-01-01T01:02:03-08:00",
@@ -539,6 +546,7 @@ class OuraClient:
                 Example:
                     [
                         {
+                            "id": "8f9a5221-639e-4a85-81cb-4065ef23f979",
                             "activity": "cycling",
                             "calories": 300,
                             "day": "2021-01-01",


### PR DESCRIPTION
This PR addresses issue #2:

## Additional v2 endpoints added:
- Spo2
- Daily stress
- Enhanced tag
- Rest mode period
- Ring configuration
- Sleep time

## Single document requests
- Added documentation of the `id` field
- Added support for requests by document id to the appropriate endpoints

## Additional updates
- The tag endpoint is deprecated in favor or enhanced tag.  A note was added to the documentation.